### PR TITLE
bug: The provided secret is encrypted with the default key.

### DIFF
--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -8,4 +8,4 @@ jobs:
     uses: clouddrove/github-shared-workflows/.github/workflows/tfsec.yml@master
     secrets: inherit
     with:
-      working_directory: '.'
+      working_directory: './_example/'

--- a/_example/example.tf
+++ b/_example/example.tf
@@ -119,7 +119,8 @@ module "secrets_manager" {
       name                    = "AmazonMSK_1"
       description             = "My secret 1"
       recovery_window_in_days = 7
-      secret_string           = "This is an example"
+      kms_key                 = module.kms_key.key_id
+      secret_string           = "{ \"username\": \"test-user\", \"password\": \"test-password\" }"
     }
   ]
 }


### PR DESCRIPTION
bug: The provided secret is encrypted with the default key.
Secret Manager was using `default key` instead of `kms-key` created for AWS-MSK.
![Screenshot from 2023-05-19 22-48-18](https://github.com/clouddrove/terraform-aws-msk/assets/83774016/93d7699f-98f9-4b0e-a5ac-708072e0c10e)


bug: The provided secret has an invalid schema.
value of `secret_string` was not a valid schema (in the form of key value pair) to use in AWS-MSK
![Screenshot from 2023-05-19 22-50-43](https://github.com/clouddrove/terraform-aws-msk/assets/83774016/27298312-51f2-4963-9a98-db84d3ec776a)
