### PR TITLE
fix: retain sasl and tls blocks when values are set to false

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -100,6 +100,12 @@ variable "client_authentication_sasl_iam" {
   description = "Enables IAM client authentication"
 }
 
+variable "client_authentication_unauthenticated" {
+  type        = bool
+  default     = false
+  description = "(Optional) Enables unauthenticated access."
+}
+
 variable "encryption_in_transit_client_broker" {
   type        = string
   default     = null


### PR DESCRIPTION
## What
Ensure empty `sasl{}` and `tls{}` blocks are retained when values are false

## Why

- Before 
	```bash
	  - client_authentication {
	      - unauthenticated = true -> null

	      - sasl {
	          - iam   = false -> null
	          - scram = false -> null
	        }

	      - tls {}
	    }
	```

- After
	```bash
	No changes. Your infrastructure matches the configuration.
	```
