### PR TITLE
fix: conditionally render TLS block in client_authentication to avoid no-op updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,18 +31,26 @@ resource "aws_msk_cluster" "msk-cluster" {
   }
 
   dynamic "client_authentication" {
-    for_each = [
-      for v in [
-        var.client_authentication_tls_certificate_authority_arns,
-        var.client_authentication_sasl_scram,
-        var.client_authentication_sasl_iam,
-        var.client_authentication_unauthenticated
-      ] : v
-    ] != [] ? [1] : []
+    for_each = (
+      (
+        var.client_authentication_tls_certificate_authority_arns != null &&
+        length(var.client_authentication_tls_certificate_authority_arns) > 0
+      ) ||
+      (var.client_authentication_sasl_scram != null) ||
+      (var.client_authentication_sasl_iam != null) ||
+      (var.client_authentication_unauthenticated != null)
+    ) ? [1] : []
 
     content {
-      tls {
-        certificate_authority_arns = var.client_authentication_tls_certificate_authority_arns
+      dynamic "tls" {
+        for_each = (
+          var.client_authentication_tls_certificate_authority_arns != null &&
+          length(var.client_authentication_tls_certificate_authority_arns) > 0
+        ) ? [1] : []
+
+        content {
+          certificate_authority_arns = var.client_authentication_tls_certificate_authority_arns
+        }
       }
 
       sasl {


### PR DESCRIPTION
## What
Conditionally renders the `tls {}` block in the `client_authentication` section of the MSK cluster resource in Terraform. The block is only included when `certificate_authority_arns` is non-empty.

## Why
To prevent unnecessary updates and avoid AWS MSK BadRequestException errors (below) when no actual security setting changes are present. This ensures clean `terraform plan` and successful `terraform apply`.
```bash
│ Error: updating MSK Cluster (arn:aws:kafka:us-east-1:123456789012:cluster/kafka-cluster/xxxx-xxxx-xxxx-xxxx-xxxxxxxx-2) security: operation error Kafka: UpdateSecurity, https response error StatusCode: 400, RequestID: xxxx-xxxx-xxxx-xxxx-xxxxxxxx, BadRequestException: The request does not include any updates to the security setting of the cluster. Verify the request, then try again.
│
│   with module.kafka.aws_msk_cluster.msk-cluster[0],
│   on .terraform/modules/kafka/main.tf line 15, in resource "aws_msk_cluster" "msk-cluster":
│   15: resource "aws_msk_cluster" "msk-cluster" {
```