### PR TITLE
fix: ignore empty tls{} block in client_authentication to avoid unnecessary drifts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,13 @@ resource "aws_msk_cluster" "msk-cluster" {
       unauthenticated = var.client_authentication_unauthenticated != null ? var.client_authentication_unauthenticated : false
     }
   }
+  
+  # Ignore empty tls{} block to avoid unnecessary drifts from AWS-managed state
+  lifecycle {
+    ignore_changes = [
+      client_authentication[0].tls
+    ]
+  }
 
 
   configuration_info {


### PR DESCRIPTION
## What
- Ignore changes to the `tls {}` block in the `client_authentication` block of MSK configuration.

## Why
- Terraform keeps detecting diffs for the empty `tls {}` block even when there’s no actual change. Ignoring it prevents unnecessary plan noise and avoids redundant updates.

```bash
  ~ resource "aws_msk_cluster" "msk-cluster" {
        id = "arn:aws:kafka:us-east-1:123456789012:cluster/kafka/xxx-xxx-xxx-xxx-xxx-2"

        # (21 unchanged attributes hidden)

      ~ client_authentication {
            # (1 unchanged attribute hidden)

          - tls {}

            # (1 unchanged block hidden)
        }

        # (6 unchanged blocks hidden)
    }
```